### PR TITLE
node-inspector version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "is2": "~0.0.3",
     "json-file-plus": "^3.0.0",
     "loopback-sdk-angular-cli": "1.x",
-    "node-inspector": "~0.7.0",
+    "node-inspector": "~0.10.0",
     "nodefly-register": "~0.3.2",
     "nopt": "~3.0.1",
     "optimist": "^0.6.1",


### PR DESCRIPTION
The old version of node-inspector has the following bug. 
http://stackoverflow.com/questions/28212529/node-inspector-not-exploding-object-properties
